### PR TITLE
Call `HLS.Helper.merge_uri/2` to save uri host on remote m3u8 files

### DIFF
--- a/lib/membrane/hls/source.ex
+++ b/lib/membrane/hls/source.ex
@@ -1,6 +1,7 @@
 defmodule Membrane.HLS.Source do
   use Membrane.Source
 
+  alias HLS.Helper
   alias HLS.FS.Reader
   alias HLS.Playlist.Media.Tracker
   alias HLS.Playlist
@@ -45,7 +46,7 @@ defmodule Membrane.HLS.Source do
   @impl true
   def handle_pad_added(pad = {Membrane.Pad, :output, {:rendition, rendition}}, _, state) do
     {:ok, pid} = Tracker.start_link(state.reader)
-    target = build_target(rendition)
+    target = Helper.merge_uri(state.master_playlist_uri, rendition.uri)
     ref = Tracker.follow(pid, target)
 
     config = %{


### PR DESCRIPTION
**[Issue Link](https://github.com/kim-company/kim_hls/issues/8)**

If a master playlist with HTTP urls contains relative paths, it cannot find the media playlists because the host is lost.

```
22:35:45.768 [error] GenServer #PID<0.1329.0> terminating
** (MatchError) no match of right hand side value: {:error, {:no_scheme}}
    (kim_hls 0.1.0) lib/hls/playlist/media/tracker.ex:56: HLS.Playlist.Media.Tracker.read_media_playlist/2
    (kim_hls 0.1.0) lib/hls/playlist/media/tracker.ex:62: HLS.Playlist.Media.Tracker.handle_refresh/2
```

Solution: call `URI.merge/2` to keep the host of the target.

**I would like to confirm with you if this is the correct solution before I focus on writing a test.**

[Example of failing m3u8 file](https://cdn1-staging.fireworktv.com/ivs/v1/170553093583/5sGNqMtXOt37/2023/10/10/16/12/TEN5nVGa2aoN/media/hls/master.m3u).